### PR TITLE
FIXED THE ISSUE WHERE CREATED BY WASNT VISIBLE (ISSUE: #89)

### DIFF
--- a/nodejs/src/services/brain.js
+++ b/nodejs/src/services/brain.js
@@ -7,7 +7,7 @@ const { sendCommonNotification } = require('./notification');
 const { addBrainChatMember, removeBrainChatMember } = require('../services/chatmember');
 const { addShareBrainTeam, addWorkSpaceTeam } = require('./teamMember');
 const { addWorkSpaceUsers } = require('./workspace');
-const Workspace =require("../models/workspace");
+const Workspace =require("../models/workspaceuser");
 const { accessOfBrainToUser, accessOfWorkspaceToUser } = require('./common');
 
 const shareBrainFormat = async (req, brains, createBrain = false) => {


### PR DESCRIPTION
There was an error where createdby field wasnt being displayed.

I saw that when brain was being created in backend service, the service used to find the workspace was using a difference workspace model instead of workspaceuser. I therefore changed the import and now it works proper

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/weam-ai/weamai/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [weam.ai](https://github.com/weam-ai/weamai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested it by running it locally and then replicating the issue by creating a new brain

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] Local unit tests pass with my changes
