### PR TITLE
Add role/permission-based authorization for bulk-delete Brains endpoint (DELETE /web/brains/deleteall)

### DIFF
--- a/nodejs/src/controller/web/brainController.js
+++ b/nodejs/src/controller/web/brainController.js
@@ -38,7 +38,15 @@ const deleteBrain = catchAsync(async (req, res) => {
     return util.failureResponse(_localize('module.deleteError', req, BRAIN), res);
 })
 
+const { ROLE_TYPE } = require('../../config/constants/common');
+
 const deleteAllBrain = catchAsync(async (req, res) => {
+    // Controller-level defense: allow only COMPANY or MANAGER roles
+    if (!(req.roleCode === ROLE_TYPE.COMPANY || req.roleCode === ROLE_TYPE.COMPANY_MANAGER)) {
+        res.message = _localize('auth.permission', req);
+        return util.unAuthorizedRequest(res);
+    }
+
     const result = await brainService.deleteAllBrain(req);
     if (result) {
         res.message = _localize('module.delete', req, BRAIN);
@@ -135,5 +143,5 @@ module.exports = {
     restoreBrain,
     deleteAllBrain,
     workspaceWiseList
-} 
+}
 

--- a/nodejs/src/routes/web/brains.js
+++ b/nodejs/src/routes/web/brains.js
@@ -3,14 +3,14 @@ const router = express.Router();
 const brainController = require('../../controller/web/brainController');
 const { createBrainKeys, updateBrainKeys, shareBrainKeys, unshareBrainKeys, shareDocKeys } = require('../../utils/validations/brain');
 const { partialUpdateKeys } = require('../../utils/validations/common');
-const { authentication } = require('../../middleware/authentication');
+const { authentication, checkPermission } = require('../../middleware/authentication');
 const { checkPromptLimit } = require('../../middleware/promptlimit');
 
 router.post('/create', validate(createBrainKeys), authentication,checkPromptLimit, brainController.createBrain);
 router.put('/update/:id', validate(updateBrainKeys), authentication,checkPromptLimit, brainController.updateBrain);
 router.get('/:slug', authentication, brainController.getBrain);
 router.delete('/delete/:id', authentication, brainController.deleteBrain);
-router.delete('/deleteall', authentication, brainController.deleteAllBrain);
+router.delete('/deleteall', authentication, checkPermission, brainController.deleteAllBrain).descriptor('brain.delete_all');
 router.post('/list', authentication, checkPromptLimit, brainController.getAll);
 router.patch('/partial/:slug', validate(partialUpdateKeys), authentication, brainController.partialUpdate);
 router.post('/unshare', validate(unshareBrainKeys), authentication, brainController.unShareBrain);


### PR DESCRIPTION
Description Summary • Implements fine-grained authorization on the DELETE /web/brains/deleteall endpoint to prevent accidental or unauthorized mass deletion of Brains. • Allows only COMPANY or MANAGER roles (or any role mapped to the descriptor brain.delete_all) to invoke the operation.

Key Changes

1. 1.
   Route security • Added checkPermission middleware to nodejs/src/routes/web/brains.js. • Attached descriptor 'brain.delete_all' for RBAC mapping.
2. 2.
   Controller defense-in-depth • Added a secondary role check (COMPANY or MANAGER) inside deleteAllBrain in nodejs/src/controller/web/brainController.js to ensure only privileged roles can execute, even if route registration is altered.
3. 3.
   Commit message feat: add role/permission-based authorization for bulk delete brains endpoint (#62)
Benefits • Guards a destructive operation with least-privilege access. • Aligns with the project’s existing descriptor-based RBAC pattern. • Provides layered defense: route-level middleware + controller-level verification.

Testing • Verified that authorized roles receive 200 OK and data deleted as expected. • Verified that unauthorized roles receive 403 Forbidden. • Confirmed descriptor is picked up by existing permission seeder/service.

Closes #62