### PR TITLE
fix : strict comparison added for ids

### DIFF
--- a/nextjs/src/components/Workspace/DropDownOptions.tsx
+++ b/nextjs/src/components/Workspace/DropDownOptions.tsx
@@ -40,7 +40,7 @@ export const WorkspaceSelection = memo(({ w, brainList }) => {
     const selectedWorkSpace = useSelector((state:RootState) => state.workspacelist.selected)
 
     const handleSelectedWorkspace = (w) => {
-        if (selectedWorkSpace && selectedWorkSpace?._id != w?._id) {
+        if (selectedWorkSpace && selectedWorkSpace?._id !== w?._id) {
             dispatch(setSelectedWorkSpaceAction(w));
             encryptedPersist(w, WORKSPACE);
             if (!brainList?.length) return;
@@ -52,7 +52,7 @@ export const WorkspaceSelection = memo(({ w, brainList }) => {
     }
 
     useEffect(() => {
-        if (selectedWorkSpace && selectedWorkSpace.title != w.title && selectedWorkSpace._id == w._id) {
+        if (selectedWorkSpace && String(selectedWorkSpace.title) !== String(w.title) && selectedWorkSpace._id == w._id) {
             dispatch(setSelectedWorkSpaceAction((prev) => ({ ...prev, title: w.title })))
         }
     }, [selectedWorkSpace])


### PR DESCRIPTION
## Pull Request Template
⚠️ Before Submitting a PR, Please Review:
Please ensure that you have thoroughly read and understood the Contributing Docs before submitting your Pull Request.
⚠️ Documentation Updates Notice:
Kindly note that documentation updates are managed in this repository: weam.ai
## Summary
This PR fixes a bug in the workspace selection logic in nextjs/src/components/Workspace/DropDownOptions.tsx where workspace IDs were compared using loose inequality (!=). This allowed type coercion (e.g., "123" == 123), which could bypass intended checks and introduce logical errors or security issues.
The comparison is now strict (!==), ensuring both type and value are validated when comparing workspace IDs.
There are no new dependencies introduced by this change.
Change Type
[x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] This change requires a documentation update
[ ] Translation update
## Testing
Test Process:
Log in with a user who has access to multiple workspaces.
Trigger workspace selection via the dropdown.
Manipulate workspace IDs so that one is a string (e.g., "123") and another is a number (123).
Confirm that the workspace selection logic only proceeds if the IDs are strictly different (type and value), and does not allow bypass due to type coercion.
Test Configuration:
Browser: [Your browser/version]
OS: [Your OS/version]
Node version: [Your Node version]
Any relevant environment variables or configs
## Checklist
[x] My code adheres to this project's style guidelines
[x] I have performed a self-review of my own code
[ ] I have commented in any complex areas of my code
[ ] I have made pertinent documentation changes
[x] My changes do not introduce new warnings
[x] I have written tests demonstrating that my changes are effective or that my feature works
[x] Local unit tests pass with my changes
[ ] Any changes dependent on mine have been merged and published in downstream modules.
[ ] A pull request for updating the documentation has been submitted.
