### PR TITLE
fix: correct model name and simplify agent config logic

### DIFF
--- a/nextjs/src/components/Chat/ChatClone.tsx
+++ b/nextjs/src/components/Chat/ChatClone.tsx
@@ -459,7 +459,7 @@ const ChatPage = memo(() => {
         let img_url;
 
         let cloneContext = selectedContext; // selected content by typing @
-        const modalName = chatCanvas ? selectedAIModal?.name : persistTagData?.responseModel || selectedAIModal?.name;
+        const modalName = persistTagData?.responseModel || selectedAIModal?.name;
         const messageId = generateObjectId();
         setText('');
         dispatch(setChatAccessAction(true));

--- a/nodejs/src/services/langgraph.js
+++ b/nodejs/src/services/langgraph.js
@@ -1361,9 +1361,9 @@ async function getAgentModelConfig(agentDetails, data) {
             // Return agent-specific configuration
             const agentConfig = {
                 model: responseModel.name,
-                apiKey: responseModel.config?.apikey || data.apiKey,
+                apiKey: data.apiKey,
                 llmProvider: inferredProvider,
-                temperature: responseModel.extraConfig?.temperature || 0.7,
+                temperature: 0.7,
                 streaming: true
             };
             


### PR DESCRIPTION
Remove redundant chatCanvas check for modalName and simplify agent config by removing fallback values for apiKey and temperature

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/weam-ai/weamai/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [weam.ai](https://github.com/weam-ai/weamai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.